### PR TITLE
[#1] removed "get()", except for the "get_children()" function

### DIFF
--- a/src/hexlet/fs/__init__.py
+++ b/src/hexlet/fs/__init__.py
@@ -29,27 +29,27 @@ def mkdir(name, children=[], meta={}):
 
 def is_directory(node):
     '''Check is node a directory.'''
-    return node.get('type') == 'directory'
+    return node['type'] == 'directory'
 
 
 def is_file(node):
     '''Check is node a file.'''
-    return node.get('type') == 'file'
+    return node['type'] == 'file'
 
 
 def get_children(directory):
     '''Return children of node.'''
-    return directory.get('children')
+    return directory.get('children', [])
 
 
 def get_meta(node):
     '''Return meta of node.'''
-    return node.get('meta')
+    return node['meta']
 
 
 def get_name(node):
     '''Return name of node.'''
-    return node.get('name')
+    return node['name']
 
 
 def flatten(tree):


### PR DESCRIPTION
    Из функций: `is_directory()`, `is_file()`, `get_meta()`, `get_name()`, обращение по ключу через `.get()` заменено на непосредственное обращение по ключу. 
    В функции `get_children()`, в параметры `get()` добавлено возвращаемое значение `[ ]` в случае отсутствия ключа `children`.  