### PR TITLE
refactor component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # python-immutable-fs-trees
 
-
 [![github action status](https://github.com/hexlet-components/python-immutable-fs-trees/workflows/Python%20CI/badge.svg)](https://github.com/hexlet-components/python-immutable-fs-trees/actions)
 
 ## Install
@@ -12,6 +11,7 @@ pip install hexlet-immutable-fs-trees
 ## Usage example
 
 ```python
+
 >>> import hexlet.fs as fs
 >>> fs.is_file(fs.mkfile('config'))
 True
@@ -24,6 +24,7 @@ True
 'config'
 >>> list(map(lambda item: fs.get_name(item), children))
 ['config', 'hosts']
+
 ```
 
 [![Hexlet Ltd. logo](https://raw.githubusercontent.com/Hexlet/hexletguides.github.io/master/images/hexlet_logo128.png)](https://ru.hexlet.io/pages/about)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,15 @@ ignore =
     WPS412        # allow __init__.py with logic
     DAR101        # allow missing parameters in Dockstring
     DAR201        # allow missing Returns in Docstring
+    # ignored to make it easier for beginners to understand the code
+    B006
+    D103
+    WPS110
+    WPS125
+    WPS202
+    WPS226
+    WPS404
+    WPS520
 
 per-file-ignores =
   # fix for Emacs's flycheck

--- a/src/hexlet/fs/__init__.py
+++ b/src/hexlet/fs/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-'''Description'''
+"""Description."""
 
 __all__ = (   # noqa: WPS317
     'mkfile', 'mkdir',
@@ -9,47 +9,47 @@ __all__ = (   # noqa: WPS317
 
 
 def mkfile(name, meta={}):
-    '''Return file node.'''
+    """Return file node."""
     return {
-            'name': name,
-            'meta': meta,
-            'type': 'file',
-           }
+        'name': name,
+        'meta': meta,
+        'type': 'file',
+    }
 
 
 def mkdir(name, children=[], meta={}):
-    '''Return directory node.'''
+    """Return directory node."""
     return {
-            'name': name,
-            'children': children,
-            'meta': meta,
-            'type': 'directory',
-           }
+        'name': name,
+        'children': children,
+        'meta': meta,
+        'type': 'directory',
+    }
 
 
 def is_directory(node):
-    '''Check is node a directory.'''
-    return node.get('type') == 'directory'
+    """Check is node a directory."""
+    return node['type'] == 'directory'
 
 
 def is_file(node):
-    '''Check is node a file.'''
-    return node.get('type') == 'file'
+    """Check is node a file."""
+    return node['type'] == 'file'
 
 
 def get_children(directory):
-    '''Return children of node.'''
-    return directory.get('children')
+    """Return children of node."""
+    return directory.get('children', [])
 
 
 def get_meta(node):
-    '''Return meta of node.'''
-    return node.get('meta')
+    """Return meta of node."""
+    return node['meta']
 
 
 def get_name(node):
-    '''Return name of node.'''
-    return node.get('name')
+    """Return name of node."""
+    return node['name']
 
 
 def flatten(tree):

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -1,4 +1,4 @@
-'''Tests for hexlet.fs_tree.'''
+"""Tests for hexlet.fs_tree."""
 
 from hexlet import fs
 
@@ -13,7 +13,7 @@ def test_build():
     tree = fs.mkdir('/', [
         fs.mkdir('etc'),
         fs.mkdir('usr'),
-        fs.mkfile('robots.txt')
+        fs.mkfile('robots.txt'),
     ])
 
     expected = {
@@ -63,7 +63,7 @@ def test_get_children():
     tree = fs.mkdir('/', [
         fs.mkdir('etc'),
         fs.mkdir('usr'),
-        fs.mkfile('robots.txt')
+        fs.mkfile('robots.txt'),
     ])
     expected = [
         {

--- a/test/test_fs.py
+++ b/test/test_fs.py
@@ -8,6 +8,7 @@ def test_is_directory():
     assert fs.is_directory(node)
     assert not fs.is_file(node)
 
+
 def test_build():
     tree = fs.mkdir('/', [
         fs.mkdir('etc'),
@@ -17,23 +18,23 @@ def test_build():
 
     expected = {
         'children': [
-          {
-            'children': [],
-            'meta': {},
-            'name': 'etc',
-            'type': 'directory',
-          },
-          {
-            'children': [],
-            'meta': {},
-            'name': 'usr',
-            'type': 'directory',
-          },
-          {
-            'meta': {},
-            'name': 'robots.txt',
-            'type': 'file',
-          },
+            {
+                'children': [],
+                'meta': {},
+                'name': 'etc',
+                'type': 'directory',
+            },
+            {
+                'children': [],
+                'meta': {},
+                'name': 'usr',
+                'type': 'directory',
+            },
+            {
+                'meta': {},
+                'name': 'robots.txt',
+                'type': 'file',
+            },
         ],
         'meta': {},
         'name': '/',
@@ -56,7 +57,7 @@ def test_get_meta():
     assert fs.get_meta(file).get('owner') == 'root'
 
 
-def test_get_meta():
+def test_get_children():
     file = fs.mkfile('robots.txt')
     dir = fs.mkdir('/')
     tree = fs.mkdir('/', [
@@ -65,27 +66,28 @@ def test_get_meta():
         fs.mkfile('robots.txt')
     ])
     expected = [
-          {
+        {
             'children': [],
             'meta': {},
             'name': 'etc',
             'type': 'directory',
-          },
-          {
+        },
+        {
             'children': [],
             'meta': {},
             'name': 'usr',
             'type': 'directory',
-          },
-          {
+        },
+        {
             'meta': {},
             'name': 'robots.txt',
             'type': 'file',
-          },
-        ]
+        },
+    ]
     assert not fs.get_children(file)
     assert fs.get_children(dir) == []
     assert fs.get_children(tree) == expected
+
 
 def test_flatten():
     assert fs.flatten([]) == []


### PR DESCRIPTION
## FIX #1
В геттерах и чекерах заменено обращение к значениям словаря через метод `.get` на обращение по ключу.
В `get_children` сохранено обращение через `.get` с установкой значения по умлочанию `[]`

## FIX #3 
Исправлено неправильное `test_get_meta` на правильное `test_get_children`

## FIX #4
Ошибки все понятные и устранить их не сложно. Но в данном случае не стоит. Для студентов будет сложнее понять код.
Предлагаю заигнорить в `setup.cfg` следующие:

- B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
- C812 missing trailing comma
- D103 Missing docstring in public function
- D300 Use “”"triple double quotes”“”
- Q002 Remove bad quotes from docstring
- WPS110 Found wrong variable name: result
- WPS125 Found builtin shadowing: dir
- WPS202 Found too many module members: 8 > 7
- WPS226 Found string constant over-use: type > 3
- WPS404 Found complex default value
- WPS520 Found compare with falsy constant
