### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+---
+version: 2
+updates:
+  # === GitHub Actions ===
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, actions]
+    groups:
+      actions-minor-patch:
+        update-types: [minor, patch]
+      actions-major:
+        update-types: [major]
+  # === Python dev (pip) ===
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, dev]
+    groups:
+      pip-dev-minor-patch:
+        patterns:
+          - pytest*
+          - flake8*
+          - black
+          - isort
+          - mypy*
+          - coverage*
+          - tox*
+          - ruff
+          - pylint*
+          - bandit
+          - pre-commit
+          - sphinx*
+          - mkdocs*
+        update-types: [minor, patch]
+  # === Python runtime (pip) ===
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, runtime]
+    groups:
+      pip-runtime-minor-patch:
+        update-types: [minor, patch]
+  # === Python (uv) ===
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, uv]
+  # === Docker ===
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    labels: [dependencies, automated, docker]


### PR DESCRIPTION
Добавил еженедельное обновление зависимостей через Dependabot

### GitHub Actions

- Обновления рабочих процессов теперь будут приходить раз в неделю
- Minor и patch обновления Actions будут сгруппированы в один PR.
- Major обновления будут вынесены в отдельные PR для безопасного анализа
    

### Python-зависимости

- **Dev-инструменты**  
    Линтеры, тестовые фреймворки, утилиты форматирования кода и другие пакеты разработки (например, `pytest`, `ruff`, `black`, `isort`, `mypy`, `coverage`, `tox`, `flake8`, `bandit`, `pre-commit`, `sphinx`, `mkdocs`).  
    Minor и patch обновления этих пакетов будут объединяться в один PR
    
- **Runtime-зависимости**  
    Все остальные пакеты, необходимые самому приложению
    Minor и patch обновления runtime останутся сгруппированными отдельно от dev-инструментов 
    Major runtime обновления приходят по одному PR
    
### UV (`uv.lock`)

- Dependabot будет отслеживать обновления **как в `pyproject.toml`, так и в `uv.lock`** 
- Для UV применяется та же логика, что и для остальных Python-зависимостей:  
    dev-инструменты и runtime-пакеты будут поступать отдельными PR-ами, с группировкой minor/patch обновлений.

### Docker

- Проверка и обновление тегов базовых образов в `Dockerfile` будет выполняться еженедельно
- Отдельные PR для каждого обновления тега, без группировок

fyi [@fey](https://github.com/fey)